### PR TITLE
[Feat] add arg includeEmpty(#1)

### DIFF
--- a/htmlparser/__tests__/utils/getElements.test.ts
+++ b/htmlparser/__tests__/utils/getElements.test.ts
@@ -77,7 +77,7 @@ describe('getElementAttributes', () => {
 
   test('存在しない要素名を指定した場合は空の配列を返す', () => {
     const contents = '<div>Content</div>';
-    const elementNames = ['div', 'span', 'p'];
+    const elementNames = ['div', 'span', 'p']
     const expected = {
       div: [{}],
       span: [],
@@ -111,4 +111,35 @@ describe('getElementAttributes', () => {
     const actual = getElementAttributes(contents, elementNames)
     expect(actual).toEqual(expected)
   })
+
+  test('includeEmptyがtrueの場合、空のオブジェクトも含まれる', () => {
+    const contents = `
+      <div id="main" class="container">
+        <span style="color: red;">Text</span>
+        <span data-value="12345">Data</span>
+      </div>`
+    const elementNames = ['div', 'span']
+    const expected = {
+      div: [{ id: 'main', class: 'container' }],
+      span: [{}, {}],
+    }
+    const actual = getElementAttributes(contents, elementNames, 'idAndClass', true)
+    expect(actual).toEqual(expected)
+  })
+
+  test('includeEmptyがfalseの場合、空のオブジェクトは含まれない', () => {
+    const contents = `
+      <div id="main" class="container">
+        <span style="color: red;">Text</span>
+        <span data-value="12345">Data</span>
+      </div>`
+    const elementNames = ['div', 'span']
+    const expected = {
+      div: [{ id: 'main', class: 'container' }],
+      span: [],
+    }
+    const actual = getElementAttributes(contents, elementNames, 'idAndClass', false)
+    expect(actual).toEqual(expected)
+  })
+
 })

--- a/htmlparser/src/index.ts
+++ b/htmlparser/src/index.ts
@@ -53,9 +53,9 @@ app.post('/parse', validator('form', () => {}), async (c) => {
         // 要素名の含まれた文字列を配列に分割
         const tags = splitString(body['elements'], [',', '+'])
         // 取得する属性を判定するオプションを取得
-        const option = getAttributeOption(body['attrs[]'])
+        const attributes = getAttributeOption(body['attrs[]'])
 
-        return c.json({ status: 200, data: getElementAttributes(contents, tags, option) })
+        return c.json({ status: 200, data: getElementAttributes(contents, tags, attributes, false) })
     }
     catch (e) {
       return c.json({ status: 500, error: 'Failed to fetch URL' })

--- a/htmlparser/src/utils/getElements.ts
+++ b/htmlparser/src/utils/getElements.ts
@@ -2,16 +2,18 @@ import * as cheerio from 'cheerio'
 import type { AttributeOption } from './../types/types'
 
 /**
- * 指定した要素名の属性と値を取得する関数
+ * 指定した要素名の属性と値を取得
  * @param {string} contents HTMLコンテンツ
  * @param {string[]} elementNames 取得する要素
- * @param {AttributeOption} option 取得する属性のオプション（初期値：all（全属性取得））
+ * @param {AttributeOption} attributeNames 取得する属性（初期値：all（全属性取得））
+ * @param {boolean} includeEmpty 空のオブジェクトも含めるか否か（初期値：true（含める））
  * @return {Object} 各要素名をキーとする属性と値の配列を持つオブジェクト
  */
 export function getElementAttributes(
     contents: string,
     elementNames: string[],
-    option: AttributeOption = 'all'
+    attributeNames: AttributeOption = 'all',
+    includeEmpty: boolean = true
 ): { [key: string]: Object[] } {
 
     const $ = cheerio.load(contents)
@@ -23,12 +25,12 @@ export function getElementAttributes(
         const attributes: Object[] = []
 
         // 指定した要素名の要素を探索
-        $(elementName).each((i, el) => {
-            const attrs = (el as cheerio.Element).attribs
+        $(elementName).each((_, element) => {
+            const attrs = (element as cheerio.Element).attribs
             const elementAttrs: { [key: string]: string } = {}
 
-            // オプションに応じて属性を抽出
-            const shouldExtractAttribute = getShouldExtractAttributeFunction(option)
+            // 取得する属性に応じた条件分岐を備えた関数を取得
+            const shouldExtractAttribute = getShouldExtractAttributeFunction(attributeNames)
 
             for (const attr in attrs) {
                 if (shouldExtractAttribute(attr)) {
@@ -36,7 +38,9 @@ export function getElementAttributes(
                 }
             }
 
-            attributes.push(elementAttrs)
+            if (includeEmpty || Object.keys(elementAttrs).length > 0) {
+                attributes.push(elementAttrs)
+            }
         })
 
         data[elementName] = attributes
@@ -46,12 +50,15 @@ export function getElementAttributes(
 }
 
 /**
- * 属性を抽出するか否かを判定する関数を返す
- * @param {AttributeOption} option 取得する属性のオプション
+ * 属性を抽出するか否かを判定する関数を取得
+ * @param {AttributeOption} attributeNames 取得する属性
  * @return {(attr: string) => boolean} 属性を抽出するか否か判定する関数
  */
-function getShouldExtractAttributeFunction(option: AttributeOption): (attr: string) => boolean {
-    switch (option) {
+function getShouldExtractAttributeFunction(
+    attributeNames: AttributeOption
+): (attr: string) => boolean {
+
+    switch (attributeNames) {
       case 'all':
         return () => true
       case 'id':


### PR DESCRIPTION
- ```utils/getElements.ts```のgetElementAttributes関数に新しい引数を追加
- ```__tests___/utils/getElement.test.ts```に2つテストケースを追加
-  ```index.ts```の```/parse```ルーティング起動時、空のオブジェクトを取得しないようにgetElementAttribuites関数の引数にfalseを設定