### PR TITLE
[Fix] remove whitespace input url and elements(#6)

### DIFF
--- a/htmlparser/__tests__/utils/stringHelpers.test.ts
+++ b/htmlparser/__tests__/utils/stringHelpers.test.ts
@@ -1,4 +1,4 @@
-import { splitString } from './../../src/utils/stringHelpers'
+import { splitString, removeWhitespace } from './../../src/utils/stringHelpers'
 
 describe('splitString', () => {
   test('空文字列を渡した場合は空の配列を返す', () => {
@@ -24,5 +24,19 @@ describe('splitString', () => {
     const actual = splitString(input, separators)
     expect(actual).toEqual(expected)
   })
+})
 
+describe("removeWhitespace", () => {
+  test("文字列から空白を除去", () => {
+    const cases = [
+      { input: " Hello   World ", expected: "HelloWorld" },  // 半角スペース
+      { input: "　　Hello　World　　", expected: "HelloWorld" },  // 全角スペース
+      { input: "Hello\n\tWorld\r", expected: "HelloWorld" },  // 改行、タブ、復帰
+      { input: "   ", expected: "" },  // 空白文字のみ
+      { input: "", expected: "" },  // 空文字列
+    ]
+    cases.forEach(({ input, expected }) => {
+      expect(removeWhitespace(input)).toBe(expected);
+    })
+  })
 })

--- a/htmlparser/src/index.ts
+++ b/htmlparser/src/index.ts
@@ -3,7 +3,7 @@ import { html } from 'hono/html'
 import { validator } from 'hono/validator'
 import type { AttributeOption } from './types/types'
 import { getAttributeOption } from './utils/attributeHelpers'
-import { splitString } from './utils/stringHelpers'
+import { splitString, removeWhitespace } from './utils/stringHelpers'
 import { getElementAttributes } from './utils/getElements'
 
 const app = new Hono()
@@ -34,24 +34,26 @@ app.get('/', (c) => {
 app.post('/parse', validator('form', () => {}), async (c) => {
     // POSTデータ取得
     const body = await c.req.parseBody()
+    const url = removeWhitespace(body['url'])
+    const elements = removeWhitespace(body['elements'])
 
     // URLのバリデーション
     const urlPattern = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([/\w?=.-]*)*\/?$/
-    if (!urlPattern.test(body['url'])) {
+    if (!urlPattern.test(url)) {
         return c.json({ status: 400, error: 'Invalid URL' })
     }
     // 要素名のバリデーション
     const elementPattern = /^[a-zA-Z0-9,+]+$/
-    if (!elementPattern.test(body['elements'])) {
+    if (!elementPattern.test(elements)) {
         return c.json({ status: 400, error: 'Invalid element names' })
     }
 
     try {
         // URLからコンテンツ取得
-        const response = await fetch(body['url'])
+        const response = await fetch(url)
         const contents = await response.text()
         // 要素名の含まれた文字列を配列に分割
-        const tags = splitString(body['elements'], [',', '+'])
+        const tags = splitString(elements, [',', '+'])
         // 取得する属性を判定するオプションを取得
         const attributes = getAttributeOption(body['attrs[]'])
 

--- a/htmlparser/src/utils/stringHelpers.ts
+++ b/htmlparser/src/utils/stringHelpers.ts
@@ -29,3 +29,12 @@ export function splitString(input: string, separators: string[]): string[] {
 
     return result
 }
+
+/**
+ * 空白を除去した文字列の取得
+ * @param {string} str 対象文字列
+ * @return {string} 空白除去後の文字列
+ */
+export function removeWhitespace(str: string): string {
+    return str.replace(/[\p{Zs}\t\n\r]+/gu, '')
+}


### PR DESCRIPTION
# 入力された値に空白が混じっているとエラーになる問題

## 解決策（変更点）
- stringHelpersに空白を除去する関数を追加
- POST送信されたURL、要素名に対して追加した関数を適用

## 修正ファイル
- ```__tests__/utils/stringHelpers.test.ts```
- ```src/utils/stringHelpers.ts```
- ```src/utils/stringHelpers.ts```