### PR TITLE
refactor:modified prepareElements(#24)

### DIFF
--- a/htmlparser/__tests__/utils/fetchUrl.test.ts
+++ b/htmlparser/__tests__/utils/fetchUrl.test.ts
@@ -1,0 +1,30 @@
+import { vi, it, describe, expect, afterEach } from 'vitest'
+import { fetchUrl } from './../../src/utils/fetchUrl'
+
+describe('fetchUrl', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('URLからコンテンツ取得', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+            text: vi.fn().mockResolvedValue('<div>Hello World</div>'),
+        })
+        global.fetch = mockFetch
+
+        const url = 'https://example.com'
+        const contents = await fetchUrl(url)
+
+        expect(mockFetch).toHaveBeenCalledWith(url)
+        expect(contents).toBe('<div>Hello World</div>')
+    })
+
+    it('不正なURLからコンテンツを取得した場合', async () => {
+        const mockFetch = vi.fn().mockRejectedValue(new Error('Fetch failed'))
+        global.fetch = mockFetch
+
+        const url = 'https://example.com'
+
+        await expect(fetchUrl(url)).rejects.toThrow('Fetch failed')
+    })
+})

--- a/htmlparser/__tests__/utils/prepareElements.test.ts
+++ b/htmlparser/__tests__/utils/prepareElements.test.ts
@@ -1,0 +1,37 @@
+import { vi, it, describe, expect } from 'vitest'
+import type { FetchDependencies } from './../../src/types'
+import { prepareElementAttributes } from './../../src/utils/prepareElements'
+
+const mockFetchUrl = vi.fn(async (url: string) => {
+    return '<div id="test">Hello World</div>'
+})
+
+const mockSplitString = vi.fn((input: string, separators: string[]) => {
+    return input.split(separators[0])
+})
+
+const mockGetAttributeOption = vi.fn((attrs: string) => {
+    return attrs.split(',')
+})
+
+const deps: FetchDependencies = {
+    fetchUrl: mockFetchUrl,
+    splitString: mockSplitString,
+    getAttributeOption: mockGetAttributeOption,
+}
+
+describe('prepareElementAttributes', () => {
+    it('解析関数に渡すURL、要素、取得属性の準備', async () => {
+        const url = 'https://example.com'
+        const elements = 'div,p'
+        const attrs = 'id,class'
+
+        const result = await prepareElementAttributes(url, elements, attrs, deps)
+
+        expect(result).toEqual({
+            contents: '<div id="test">Hello World</div>',
+            tags: ['div', 'p'],
+            attributes: ['id', 'class'],
+        })
+    })
+})

--- a/htmlparser/src/index.ts
+++ b/htmlparser/src/index.ts
@@ -1,14 +1,22 @@
 import { Hono } from 'hono'
 import { html } from 'hono/html'
 import { validator } from 'hono/validator'
+import type { FetchDependencies } from './types'
 import { getAttributeOption } from './helpers/attributeHelpers'
 import { splitString, removeWhitespace } from './helpers/stringHelpers'
+import { fetchUrl } from './utils/fetchUrl'
 import { prepareElementAttributes } from './utils/prepareElements'
 import { getElementAttributes } from './parsers/getElements'
 import { matchesUrlPattern, matchesElementNamePattern } from './validators'
 import { convertToCSV } from './utils/csvConverter'
 
 const app = new Hono()
+
+const fetchDeps: FetchDependencies = {
+    fetchUrl,
+    splitString,
+    getAttributeOption,
+}
 
 // 検証用フォーム
 app.get('/', c => {
@@ -58,6 +66,7 @@ app.post(
                 url,
                 elements,
                 attrs,
+                fetchDeps,
             )
 
             const data = getElementAttributes(contents, tags, attributes, false)
@@ -96,6 +105,7 @@ app.post(
                 url,
                 elements,
                 attrs,
+                fetchDeps,
             )
 
             const data = getElementAttributes(contents, tags, attributes, false)
@@ -135,6 +145,7 @@ app.post(
                 url,
                 elements,
                 attrs,
+                fetchDeps,
             )
 
             const data = getElementAttributes(contents, tags, attributes, false)

--- a/htmlparser/src/types/index.ts
+++ b/htmlparser/src/types/index.ts
@@ -1,8 +1,15 @@
 export type AttributeOption = 'all' | 'id' | 'class' | 'idAndClass'
 export type ElementAttributes = { [key: string]: string }
 export type ElementAttributesMap = { [key: string]: ElementAttributes[] }
+
 export type PreparedElementAttributes = {
     contents: string
     tags: string[]
     attributes: AttributeOption
+}
+
+export type FetchDependencies = {
+    fetchUrl: (url: string) => Promise<string>
+    splitString: (str: string, separators: string[]) => string[]
+    getAttributeOption: (attrs: string) => string[]
 }

--- a/htmlparser/src/utils/fetchUrl.ts
+++ b/htmlparser/src/utils/fetchUrl.ts
@@ -1,0 +1,9 @@
+/**
+ * URLからコンテンツ取得
+ * @param {string} url URL
+ * @return {Promise<string>} コンテンツ
+ */
+export async function fetchUrl(url: string): Promise<string> {
+    const response = await fetch(url)
+    return await response.text()
+}

--- a/htmlparser/src/utils/prepareElements.ts
+++ b/htmlparser/src/utils/prepareElements.ts
@@ -1,22 +1,23 @@
-import type { PreparedElementAttributes } from './../types'
-import { getAttributeOption } from './../helpers/attributeHelpers'
-import { splitString } from './../helpers/stringHelpers'
+import type { PreparedElementAttributes, FetchDependencies } from './../types'
 
 /**
  * 指定されたURLからコンテンツを取得し、要素名の文字列を分割し、属性オプションを準備
  * @param {string} url URL
  * @param {string} elements カンマやプラスで区切られた要素名の文字列
  * @param {string} attrs 取得する属性を指定する文字列
- * @return {Promise<PreparedElementAttributes>} 要素名の配列、および属性オプションを含むオブジェクト
+ * @param {FetchDependencies} fetchDeps 依存する fetch 関連の関数オブジェクト
+ * @return {PreparedElementAttributes} 要素名の配列、および属性オプションを含むオブジェクト
  */
 export async function prepareElementAttributes(
     url: string,
     elements: string,
     attrs: string,
-): Promise<PreparedElementAttributes> {
+    fetchDeps: FetchDependencies,
+): PreparedElementAttributes {
+    const { fetchUrl, splitString, getAttributeOption } = fetchDeps
+
     // URLからコンテンツ取得
-    const response = await fetch(url)
-    const contents = await response.text()
+    const contents = await fetchUrl(url)
     // 要素名の含まれた文字列を配列に分割
     const tags = splitString(elements, [',', '+'])
     // 取得する属性を判定するオプションを取得

--- a/htmlparser/tsconfig.json
+++ b/htmlparser/tsconfig.json
@@ -5,7 +5,11 @@
         "moduleResolution": "Bundler",
         "strict": true,
         "lib": ["ESNext"],
-        "types": ["@cloudflare/workers-types", "jest"],
+        "types": [
+            "@cloudflare/workers-types",
+            "vitest/globals",
+            "jest"
+        ],
         "jsx": "react-jsx",
         "jsxImportSource": "hono/jsx",
         "esModuleInterop": true


### PR DESCRIPTION
## Modified

 - ```utils/prepareElements.ts```の修正
 - ```utils/fetchUrl.ts```の追加
 - 上2つのファイルのテストコード追加
 - ```tsconfig.json```の修正（ただし、下記に記す通り効果はなかった）

## Notes

### テストコードを作成しやすくするために行ったこと

1. **副作用のある処理を分離**
URLからコンテンツを取得する処理と要素名や属性オプションの準備が混在しているため、これらを分離することで、テストの実行を容易にした

2. **依存関数をインジェクション**
splitStringやgetAttributeOptionといった依存関数をインジェクションし、それらの振る舞いをモックできるように修正

3. **Pure関数に変換**
副作用がなく、同じ入力に対して同じ出力を返す関数に変換した

### VitestのテストAPIが利用できない

テストファイルに以下のようにimport文を追記しないとモック等が作成できなかった

```ts
import { vi, it, describe, expect } from 'vitest'
```

```tsconfig.json```に以下のように追記したが効果はなかった

```json
"vitest/globals"
```