### PR TITLE
[Refactor] ハードコーディングされた属性組み合わせを柔軟な配列ベースのアプローチに変更

### DIFF
--- a/htmlparser/__tests__/helpers/attributeHelpers.test.ts
+++ b/htmlparser/__tests__/helpers/attributeHelpers.test.ts
@@ -1,32 +1,69 @@
-import { getAttributeOption } from './../../src/helpers/attributeHelpers'
+import { getAttributeOption, shouldExtractAttribute } from './../../src/helpers/attributeHelpers'
 
 describe('getAttributeOption', () => {
-    it('"id"と"class"の両方が含まれる場合は"idAndClass"を返す', () => {
-        const attrs = ['id', 'class']
-        const result = getAttributeOption(attrs)
-        expect(result).toBe('idAndClass')
-    })
-
-    it('"id"のみが含まれる場合は"id"を返す', () => {
-        const attrs = ['id']
-        const result = getAttributeOption(attrs)
-        expect(result).toBe('id')
-    })
-
-    it('"class"のみが含まれる場合は"class"を返す', () => {
-        const attrs = ['class']
-        const result = getAttributeOption(attrs)
-        expect(result).toBe('class')
-    })
-
-    it('"id"と"class"以外の値が含まれる場合は"all"を返す', () => {
-        const attrs = ['other']
-        const result = getAttributeOption(attrs)
+    it('空文字列の場合は"all"を返す', () => {
+        const result = getAttributeOption('')
         expect(result).toBe('all')
     })
 
     it('引数なしの場合は"all"を返す', () => {
         const result = getAttributeOption()
         expect(result).toBe('all')
+    })
+
+    it('空配列の場合は"all"を返す', () => {
+        const result = getAttributeOption([])
+        expect(result).toBe('all')
+    })
+
+    it('"all"文字列の場合は"all"を返す', () => {
+        const result = getAttributeOption('all')
+        expect(result).toBe('all')
+    })
+
+    it('単一の文字列の場合は配列として返す', () => {
+        const result = getAttributeOption('id')
+        expect(result).toEqual(['id'])
+    })
+
+    it('文字列の配列の場合はそのまま返す', () => {
+        const attrs = ['id', 'class']
+        const result = getAttributeOption(attrs)
+        expect(result).toEqual(['id', 'class'])
+    })
+
+    it('複数の属性を含む配列の場合はそのまま返す', () => {
+        const attrs = ['id', 'class', 'src', 'href']
+        const result = getAttributeOption(attrs)
+        expect(result).toEqual(['id', 'class', 'src', 'href'])
+    })
+})
+
+describe('shouldExtractAttribute', () => {
+    it('"all"の場合はどの属性でもtrueを返す', () => {
+        expect(shouldExtractAttribute('id', 'all')).toBe(true)
+        expect(shouldExtractAttribute('class', 'all')).toBe(true)
+        expect(shouldExtractAttribute('src', 'all')).toBe(true)
+        expect(shouldExtractAttribute('custom-attr', 'all')).toBe(true)
+    })
+
+    it('配列に含まれる属性の場合はtrueを返す', () => {
+        const targetAttrs = ['id', 'class', 'src']
+        expect(shouldExtractAttribute('id', targetAttrs)).toBe(true)
+        expect(shouldExtractAttribute('class', targetAttrs)).toBe(true)
+        expect(shouldExtractAttribute('src', targetAttrs)).toBe(true)
+    })
+
+    it('配列に含まれない属性の場合はfalseを返す', () => {
+        const targetAttrs = ['id', 'class']
+        expect(shouldExtractAttribute('src', targetAttrs)).toBe(false)
+        expect(shouldExtractAttribute('href', targetAttrs)).toBe(false)
+        expect(shouldExtractAttribute('alt', targetAttrs)).toBe(false)
+    })
+
+    it('空配列の場合はfalseを返す', () => {
+        const targetAttrs: string[] = []
+        expect(shouldExtractAttribute('id', targetAttrs)).toBe(false)
+        expect(shouldExtractAttribute('class', targetAttrs)).toBe(false)
     })
 })

--- a/htmlparser/__tests__/parsers/getElements.test.ts
+++ b/htmlparser/__tests__/parsers/getElements.test.ts
@@ -157,7 +157,12 @@ describe('getElementAttributes', () => {
             div: [{ 'data-component': 'header', 'aria-label': 'Main navigation' }],
             button: [{ 'data-action': 'toggle', 'aria-expanded': 'false' }],
         }
-        const actual = getElementAttributes(contents, elementNames, ['data-component', 'aria-label', 'data-action', 'aria-expanded'])
+        const actual = getElementAttributes(contents, elementNames, [
+            'data-component',
+            'aria-label',
+            'data-action',
+            'aria-expanded',
+        ])
         expect(actual).toEqual(expected)
     })
 })

--- a/htmlparser/__tests__/parsers/getElements.test.ts
+++ b/htmlparser/__tests__/parsers/getElements.test.ts
@@ -38,7 +38,7 @@ describe('getElementAttributes', () => {
             div: [{ id: 'main' }],
             span: [{}, {}],
         }
-        const actual = getElementAttributes(contents, elementNames, 'id')
+        const actual = getElementAttributes(contents, elementNames, ['id'])
         expect(actual).toEqual(expected)
     })
 
@@ -53,7 +53,7 @@ describe('getElementAttributes', () => {
             div: [{ class: 'container' }],
             span: [{}, {}],
         }
-        const actual = getElementAttributes(contents, elementNames, 'class')
+        const actual = getElementAttributes(contents, elementNames, ['class'])
         expect(actual).toEqual(expected)
     })
 
@@ -68,7 +68,22 @@ describe('getElementAttributes', () => {
             div: [{ id: 'main', class: 'container' }],
             span: [{}, {}],
         }
-        const actual = getElementAttributes(contents, elementNames, 'idAndClass')
+        const actual = getElementAttributes(contents, elementNames, ['id', 'class'])
+        expect(actual).toEqual(expected)
+    })
+
+    it('複数の属性（id, class, src）を取得できる', () => {
+        const contents = `
+      <div id="main" class="container" data-test="value">
+        <img src="image1.jpg" alt="Image 1" class="photo">
+        <img src="image2.jpg" data-id="img2">
+      </div>`
+        const elementNames = ['div', 'img']
+        const expected = {
+            div: [{ id: 'main', class: 'container' }],
+            img: [{ src: 'image1.jpg', class: 'photo' }, { src: 'image2.jpg' }],
+        }
+        const actual = getElementAttributes(contents, elementNames, ['id', 'class', 'src'])
         expect(actual).toEqual(expected)
     })
 
@@ -113,7 +128,7 @@ describe('getElementAttributes', () => {
             div: [{ id: 'main', class: 'container' }],
             span: [{}, {}],
         }
-        const actual = getElementAttributes(contents, elementNames, 'idAndClass', true)
+        const actual = getElementAttributes(contents, elementNames, ['id', 'class'], true)
         expect(actual).toEqual(expected)
     })
 
@@ -128,7 +143,21 @@ describe('getElementAttributes', () => {
             div: [{ id: 'main', class: 'container' }],
             span: [],
         }
-        const actual = getElementAttributes(contents, elementNames, 'idAndClass', false)
+        const actual = getElementAttributes(contents, elementNames, ['id', 'class'], false)
+        expect(actual).toEqual(expected)
+    })
+
+    it('カスタム属性（data-*, aria-*など）を取得できる', () => {
+        const contents = `
+      <div data-component="header" aria-label="Main navigation">
+        <button data-action="toggle" aria-expanded="false">Menu</button>
+      </div>`
+        const elementNames = ['div', 'button']
+        const expected = {
+            div: [{ 'data-component': 'header', 'aria-label': 'Main navigation' }],
+            button: [{ 'data-action': 'toggle', 'aria-expanded': 'false' }],
+        }
+        const actual = getElementAttributes(contents, elementNames, ['data-component', 'aria-label', 'data-action', 'aria-expanded'])
         expect(actual).toEqual(expected)
     })
 })

--- a/htmlparser/__tests__/utils/prepareElements.test.ts
+++ b/htmlparser/__tests__/utils/prepareElements.test.ts
@@ -10,8 +10,10 @@ const mockSplitString = vi.fn((input: string, separators: string[]) => {
     return input.split(separators[0])
 })
 
-const mockGetAttributeOption = vi.fn((attrs: string) => {
-    return attrs.split(',')
+const mockGetAttributeOption = vi.fn((attrs: string | string[]) => {
+    if (attrs === '' || attrs === 'all') return 'all'
+    if (typeof attrs === 'string') return [attrs]
+    return attrs
 })
 
 const deps: FetchDependencies = {
@@ -21,17 +23,59 @@ const deps: FetchDependencies = {
 }
 
 describe('prepareElementAttributes', () => {
-    it('解析関数に渡すURL、要素、取得属性の準備', async () => {
+    it('解析関数に渡すURL、要素、取得属性の準備（文字列属性）', async () => {
         const url = 'https://example.com'
         const elements = 'div,p'
-        const attrs = 'id,class'
+        const attrs = 'id'
 
         const result = await prepareElementAttributes(url, elements, attrs, deps)
 
         expect(result).toEqual({
             contents: '<div id="test">Hello World</div>',
             tags: ['div', 'p'],
-            attributes: ['id', 'class'],
+            attributes: ['id'],
+        })
+    })
+
+    it('解析関数に渡すURL、要素、取得属性の準備（配列属性）', async () => {
+        const url = 'https://example.com'
+        const elements = 'div,p'
+        const attrs = ['id', 'class', 'src']
+
+        const result = await prepareElementAttributes(url, elements, attrs, deps)
+
+        expect(result).toEqual({
+            contents: '<div id="test">Hello World</div>',
+            tags: ['div', 'p'],
+            attributes: ['id', 'class', 'src'],
+        })
+    })
+
+    it('空の属性配列の場合は"all"を返す', async () => {
+        const url = 'https://example.com'
+        const elements = 'div,p'
+        const attrs: string[] = []
+
+        const result = await prepareElementAttributes(url, elements, attrs, deps)
+
+        expect(result).toEqual({
+            contents: '<div id="test">Hello World</div>',
+            tags: ['div', 'p'],
+            attributes: 'all',
+        })
+    })
+
+    it('属性が空文字列の場合は"all"を返す', async () => {
+        const url = 'https://example.com'
+        const elements = 'div,p'
+        const attrs = ''
+
+        const result = await prepareElementAttributes(url, elements, attrs, deps)
+
+        expect(result).toEqual({
+            contents: '<div id="test">Hello World</div>',
+            tags: ['div', 'p'],
+            attributes: 'all',
         })
     })
 })

--- a/htmlparser/src/helpers/attributeHelpers.ts
+++ b/htmlparser/src/helpers/attributeHelpers.ts
@@ -2,12 +2,39 @@ import type { AttributeOption } from './../types'
 
 /**
  * 属性名の配列から属性オプションを取得
- * @param {string[]|string} attrs 属性名（初期値：''）
- * @return {AttributeOption} all | id | class | idAndClass
+ * @param {string[]|string} attrs 属性名の配列または文字列
+ * @return {AttributeOption} 'all' | 属性名の配列
  */
 export function getAttributeOption(attrs: string[] | string = ''): AttributeOption {
-    if (attrs.includes('id') && attrs.includes('class')) return 'idAndClass'
-    if (attrs.includes('id')) return 'id'
-    if (attrs.includes('class')) return 'class'
-    return 'all'
+    // 空の場合は全属性を取得
+    if (!attrs || (Array.isArray(attrs) && attrs.length === 0) || attrs === '') {
+        return 'all'
+    }
+
+    // 'all'の場合は文字列なので配列に変換
+    if (typeof attrs === 'string') {
+        return attrs === 'all' ? 'all' : [attrs]
+    }
+
+    return attrs
+}
+
+/**
+ * 指定された属性が取得対象かどうかを判定
+ * @param {string} attr 判定する属性名
+ * @param {AttributeOption} targetAttrs 取得対象の属性
+ * @return {boolean} 取得対象の場合はtrue
+ */
+export function shouldExtractAttribute(attr: string, targetAttrs: AttributeOption): boolean {
+    // 'all'の場合はすべての属性を取得
+    if (targetAttrs === 'all') {
+        return true
+    }
+
+    // 配列の場合は指定された属性名が含まれているか確認
+    if (Array.isArray(targetAttrs)) {
+        return targetAttrs.includes(attr)
+    }
+
+    return false
 }

--- a/htmlparser/src/index.ts
+++ b/htmlparser/src/index.ts
@@ -43,7 +43,9 @@ app.get('/', c => {
                         URL:<input type="url" name="url"><br>
                         要素名：<input type="text" name="elements"><br>
                         id <input type="checkbox" name="attrs[]" value="id">
-                        class <input type="checkbox" name="attrs[]" value="class"><br>
+                        class <input type="checkbox" name="attrs[]" value="class">
+                        src <input type="checkbox" name="attrs[]" value="src">
+                        href <input type="checkbox" name="attrs[]" value="href"><br>
                         <input type="submit" formaction="/parse" value="解析">
                         <input type="submit" formaction="/parse/json" value="解析結果DL(JSON)">
                         <input type="submit" formaction="/parse/csv" value="解析結果DL(CSV)">

--- a/htmlparser/src/parsers/getElements.ts
+++ b/htmlparser/src/parsers/getElements.ts
@@ -1,5 +1,6 @@
 import * as cheerio from 'cheerio'
 import type { AttributeOption, ElementAttributes, ElementAttributesMap } from './../types'
+import { shouldExtractAttribute } from '../helpers/attributeHelpers'
 
 /**
  * 指定した要素名の属性と値を取得
@@ -13,7 +14,7 @@ export function getElementAttributes(
     contents: string,
     elementNames: string[],
     attributeNames: AttributeOption = 'all',
-    includeEmpty: boolean = true,
+    includeEmpty = true,
 ): ElementAttributesMap {
     const $ = cheerio.load(contents)
 
@@ -27,11 +28,9 @@ export function getElementAttributes(
             const attrs = (element as cheerio.Element).attribs
             const elementAttrs: ElementAttributes = {}
 
-            // 取得する属性に応じた条件分岐を備えた関数を取得
-            const shouldExtractAttribute = getShouldExtractAttributeFunction(attributeNames)
-
+            // 各属性をチェックして、取得対象の場合のみ追加
             for (const attr in attrs) {
-                if (shouldExtractAttribute(attr)) {
+                if (shouldExtractAttribute(attr, attributeNames)) {
                     elementAttrs[attr] = attrs[attr]
                 }
             }
@@ -45,24 +44,4 @@ export function getElementAttributes(
     })
 
     return data
-}
-
-/**
- * 属性を抽出するか否かを判定する関数を取得
- * @param {AttributeOption} attributeNames 取得する属性
- * @return {(attr: string) => boolean} 属性を抽出するか否か判定する関数
- */
-function getShouldExtractAttributeFunction(
-    attributeNames: AttributeOption,
-): (attr: string) => boolean {
-    switch (attributeNames) {
-        case 'all':
-            return () => true
-        case 'id':
-            return attr => attr === 'id'
-        case 'class':
-            return attr => attr === 'class'
-        case 'idAndClass':
-            return attr => attr === 'id' || attr === 'class'
-    }
 }

--- a/htmlparser/src/types/index.ts
+++ b/htmlparser/src/types/index.ts
@@ -1,4 +1,4 @@
-export type AttributeOption = 'all' | 'id' | 'class' | 'idAndClass'
+export type AttributeOption = 'all' | string[]
 export type ElementAttributes = { [key: string]: string }
 export type ElementAttributesMap = { [key: string]: ElementAttributes[] }
 
@@ -11,5 +11,5 @@ export type PreparedElementAttributes = {
 export type FetchDependencies = {
     fetchUrl: (url: string) => Promise<string>
     splitString: (str: string, separators: string[]) => string[]
-    getAttributeOption: (attrs: string) => string[]
+    getAttributeOption: (attrs: string[] | string) => AttributeOption
 }

--- a/htmlparser/src/utils/prepareElements.ts
+++ b/htmlparser/src/utils/prepareElements.ts
@@ -17,14 +17,14 @@ export async function prepareElementAttributes(
     const { fetchUrl, splitString, getAttributeOption } = fetchDeps
     const contents = await fetchUrl(url)
     const tags = splitString(elements, [',', '+'])
-    
+
     let processedAttrs: string | string[] = attrs
-    
+
     // フォームから来た場合（配列の場合）の処理
     if (Array.isArray(attrs)) {
         processedAttrs = attrs.length > 0 ? attrs : 'all'
     }
-    
+
     const attributes = getAttributeOption(processedAttrs)
 
     return { contents, tags, attributes }

--- a/htmlparser/src/utils/prepareElements.ts
+++ b/htmlparser/src/utils/prepareElements.ts
@@ -11,17 +11,21 @@ import type { PreparedElementAttributes, FetchDependencies } from './../types'
 export async function prepareElementAttributes(
     url: string,
     elements: string,
-    attrs: string,
+    attrs: string | string[], // 文字列または文字列配列を受け取る
     fetchDeps: FetchDependencies,
 ): PreparedElementAttributes {
     const { fetchUrl, splitString, getAttributeOption } = fetchDeps
-
-    // URLからコンテンツ取得
     const contents = await fetchUrl(url)
-    // 要素名の含まれた文字列を配列に分割
     const tags = splitString(elements, [',', '+'])
-    // 取得する属性を判定するオプションを取得
-    const attributes = getAttributeOption(attrs)
+    
+    let processedAttrs: string | string[] = attrs
+    
+    // フォームから来た場合（配列の場合）の処理
+    if (Array.isArray(attrs)) {
+        processedAttrs = attrs.length > 0 ? attrs : 'all'
+    }
+    
+    const attributes = getAttributeOption(processedAttrs)
 
     return { contents, tags, attributes }
 }


### PR DESCRIPTION
- Remove hardcoded 'idAndClass' pattern in favor of string arrays
- Add shouldExtractAttribute helper function for dynamic attribute filtering  
- Update AttributeOption type to support 'all' | string[]
- Modify getAttributeOption to handle both string and array inputs
- Simplify getElementAttributes by removing complex switch statement
- Update form processing to support multiple attribute selections
- Add comprehensive test coverage for new flexible attribute system

BREAKING CHANGE: AttributeOption type changed from specific strings to flexible arrays

---

- ハードコーディングされた 『idAndClass』 パターンを文字列配列に置き換え
- 動的な属性フィルタリング用の shouldExtractAttribute ヘルパー関数を追加
- AttributeOption 型を 『all』 | string[] をサポートするように更新
- getAttributeOption を変更し、文字列と配列の両方の入力を処理できるように変更
- 複雑な switch 文を削除して getElementAttributes を簡素化
- フォーム処理を更新し、複数の属性選択をサポートするように変更
- 新しい柔軟な属性システムのための包括的なテストカバレッジを追加

重大な変更: AttributeOption 型を特定の文字列から柔軟な配列に変更した