### PR TITLE
[chore]update devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:20
+FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
 ENV BUN_INSTALL=/usr/local
 RUN curl -fsSL https://bun.sh/install | bash


### PR DESCRIPTION
フロントエンド側のDevContainerのイメージのnodeがバージョン22なので、そちらにそろえる